### PR TITLE
Fix list index out of range error

### DIFF
--- a/s2apler/data.py
+++ b/s2apler/data.py
@@ -50,7 +50,7 @@ class Author(NamedTuple):
 
 class Paper(NamedTuple):
     title: str
-    abstract: str
+    abstract: Optional[str]
     has_abstract: Optional[bool]
     title_ngrams_words: Optional[Counter]
     abstract_ngrams_words: Optional[Counter]
@@ -920,7 +920,9 @@ def preprocess_paper_1(item: Tuple[str, Paper]) -> Tuple[str, Paper]:
     key, paper = item
 
     title = normalize_text(paper.title)
-    abstract = normalize_text(paper.abstract)
+    abstract = ""
+    if paper.has_abstract:
+        abstract = normalize_text(paper.abstract)
     if paper.title is None:
         title_lower_simple = ""
     else:

--- a/s2apler/text.py
+++ b/s2apler/text.py
@@ -478,7 +478,7 @@ def normalize_text(text: Optional[str], special_case_apostrophes_and_dashes: boo
         try:
             text = latex_to_text(text)
         except IndexError as e:
-            logger.debug(f"Failed to convert latex to text: {text}")
+            logger.debug(f"Failed to convert latex to text with: {text} and error {e}")
     norm_text = unidecode(text).lower()
 
     if special_case_apostrophes_and_dashes:

--- a/s2apler/text.py
+++ b/s2apler/text.py
@@ -9,6 +9,7 @@ from itertools import zip_longest
 import warnings
 import numpy as np
 import pandas as pd
+import logging
 from numpy import inner
 from numpy.linalg import norm
 from collections import Counter
@@ -17,6 +18,8 @@ from text_unidecode import unidecode
 import jellyfish
 
 from s2apler.consts import NUMPY_NAN
+
+logger = logging.getLogger("s2apler")
 
 latex_to_text = LatexNodes2Text().latex_to_text
 
@@ -472,7 +475,10 @@ def normalize_text(text: Optional[str], special_case_apostrophes_and_dashes: boo
     # if there is the possibility of latex
     # we can convert it to text
     if "\\" in text or text.count("$") > 1:
-        text = latex_to_text(text)
+        try:
+            text = latex_to_text(text)
+        except IndexError as e:
+            logger.debug(f"Failed to convert latex to text: {text}")
     norm_text = unidecode(text).lower()
 
     if special_case_apostrophes_and_dashes:

--- a/s2apler/timo/integration_test.py
+++ b/s2apler/timo/integration_test.py
@@ -439,6 +439,8 @@ class TestInterfaceIntegration(unittest.TestCase):
         cluster_predictions = container.predict_batch(instances)[0].prediction
 
         # the cluster seed requirement is fulfilled
-        self.assertEqual(set(cluster_predictions["0"]), {"1448693640485408768", "3406298321", "3371683470", "3206548605"})
+        self.assertEqual(
+            set(cluster_predictions["0"]), {"1448693640485408768", "3406298321", "3371683470", "3206548605"}
+        )
         # more expected results
         self.assertEqual(set(cluster_predictions["1"]), {"1591643905", "2459452638", "2468186458"})

--- a/s2apler/timo/integration_test.py
+++ b/s2apler/timo/integration_test.py
@@ -436,6 +436,9 @@ PAPERS = {
 class TestInterfaceIntegration(unittest.TestCase):
     def test__predictions(self, container):
         instances = [Instance(papers=PAPERS, cluster_seeds=CLUSTER_SEEDS)]
-        predictions = container.predict_batch(instances)[0]
-        preds_sub = predictions.prediction["nondestructivetablethardnesstesting_2"]
-        self.assertEqual(set(preds_sub), {"1591643905", "2459452638", "2468186458"})
+        cluster_predictions = container.predict_batch(instances)[0].prediction
+
+        # the cluster seed requirement is fulfilled
+        self.assertEqual(set(cluster_predictions["0"]), {"1448693640485408768", "3406298321", "3371683470", "3206548605"})
+        # more expected results
+        self.assertEqual(set(cluster_predictions["1"]), {"1591643905", "2459452638", "2468186458"})

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ requirements = [r for r in open(requirements_file).read().split("\n") if not re.
 
 setuptools.setup(
     name="s2apler",
-    version="0.2.4",
+    version="0.2.5",
     description="S2APLER: Semantic Scholar (S2) Agglomeration of Papers with Low Error Rate",
     url="https://github.com/allenai/S2APLER",
     packages=setuptools.find_packages(),


### PR DESCRIPTION
addresses s2apler list index out of range https://github.com/allenai/scholar/issues/38304 and is a fix for at least some DLQ messages in alt-p-clust https://github.com/allenai/scholar/issues/38587

What's happening: we are sometimes failing to convert detected latex to text, so when we get certain abstracts, seems like we end up w no latex nodes and therefore an index error. 

**Some examples of abstracts causing the error:**
```
    The adoption of cloud computing has brought significant advancements in the operational models of businesses. However, this shift also brings new security challenges by expanding the attack surface. The offered services in cloud computing have various service models. Each cloud service model has a defined responsibility divided based on the stack layers between the service user and their cloud provider. Regardless of its service model, each service is constructed from sub-components and services running on the underlying layers. In this paper, we aim to enable more transparency and visibility by designing an ontology that links the provider's services with the sub-components used to deliver the service. Such breakdown for each cloud service sub-components enables the end user to track the vulnerabilities on the service level or one of its sub-components. Such information can result in a better understanding and management of reported vulnerabilities on the sub-components level and their impact on the offered services by the cloud provider. Our ontology and source code are published as an open-source and accessible via GitHub: \\href{https://github.com/mohkharma/cc-ontology}{mohkharma/cc-ontology}
```
```
    In this paper, we study the problem of end-to-end multi-person pose estimation. State-of-the-art solutions adopt the DETR-like framework, and mainly develop the complex decoder, e.g., regarding pose estimation as keypoint box detection and combining with human detection in ED-Pose, hierarchically predicting with pose decoder and joint (keypoint) decoder in PETR. We present a simple yet effective transformer approach, named Group Pose. We simply regard $K$-keypoint pose estimation as predicting a set of $N\\times K$ keypoint positions, each from a keypoint query, as well as representing each pose with an instance query for scoring $N$ pose predictions. Motivated by the intuition that the interaction, among across-instance queries of different types, is not directly helpful, we make a simple modification to decoder self-attention. We replace single self-attention over all the $N\\times(K+1)$ queries with two subsequent group self-attentions: (i) $N$ within-instance self-attention, with each over $K$ keypoint queries and one instance query, and (ii) $(K+1)$ same-type across-instance self-attention, each over $N$ queries of the same type. The resulting decoder removes the interaction among across-instance type-different queries, easing the optimization and thus improving the performance. Experimental results on MS COCO and CrowdPose show that our approach without human box supervision is superior to previous methods with complex decoders, and even is slightly better than ED-Pose that uses human box supervision. $\\href{https://github.com/Michel-liu/GroupPose-Paddle}{\\rm Paddle}$ and $\\href{https://github.com/Michel-liu/GroupPose}{\\rm PyTorch}$ code are available.
```
```
    The adoption of cloud computing has brought significant advancements in the operational models of businesses. However, this shift also brings new security challenges by expanding the attack surface. The offered services in cloud computing have various service models. Each cloud service model has a defined responsibility divided based on the stack layers between the service user and their cloud provider. Regardless of its service model, each service is constructed from sub-components and services running on the underlying layers. In this paper, we aim to enable more transparency and visibility by designing an ontology that links the provider's services with the sub-components used to deliver the service. Such breakdown for each cloud service sub-components enables the end user to track the vulnerabilities on the service level or one of its sub-components. Such information can result in a better understanding and management of reported vulnerabilities on the sub-components level and their impact on the offered services by the cloud provider. Our ontology and source code are published as an open-source and accessible via GitHub: \\href{https://github.com/mohkharma/cc-ontology}{mohkharma/cc-ontology}
```
```
    LiDB is a newly developed database of molecular vibrational and vibronic state radiative lifetimes. It has been created with the aim of enabling radiative effects to be properly captured in low-temperature plasma models. Datasets have been generated for 36 molecules using comprehensive and highly accurate molecular line lists from the ExoMol spectroscopic database. The main data output of LiDB is radiative lifetimes at vibrational state resolution. Partial lifetimes, which give information on the dominant decay channels in a molecule, are also provided. LiDB is freely available to the scientific community and is hosted at \\href{www.exomol.com/lidb}{www.exomol.com/lidb}. Users can dynamically view molecular datasets or use a specially-designed application programming interface (API) to make data requests. LiDB will continue to expand in the future by adding more molecules, important isotopologues, and neutral and singly-charged atomic species.
```

they all have `\\href{link}{link-text}` -- and since we're just using this to get word similarity i think it's ok to use the text as is rather than skip/fail.

todo:

- [x] tt publish 0.2.5
- [x] upgrade version in [timo](https://github.com/allenai/timo/blob/e7a2adb48a2fc8127cd883a83fb5f83d865313c5/timo_services/configs/s2apler_v1.py)
      I see that s2apler 0.2.4 has not been deployed in timo and I am wondering if y'all think it's OK to deploy this (0.2.5) without deploying 0.2.4 first. (?)