### PR TITLE
turn off as much concurrency as possible

### DIFF
--- a/s2apler/timo/interface.py
+++ b/s2apler/timo/interface.py
@@ -80,7 +80,7 @@ class PredictorConfig(BaseSettings):
     vars the consuming application needs to set.
     """
 
-    n_jobs: int = Field(default=4, description="number of jobs to use for parallelization", required=False)
+    n_jobs: int = Field(default=1, description="number of jobs to use for parallelization", required=False)
     use_default_constraints_as_supervision: bool = Field(
         default=True,
         description="Whether to use the default constraints when constructing the distance matrices. These are high precision and can save a lot of compute/time.",
@@ -131,6 +131,8 @@ class Predictor:
             self.clusterer.set_params({"eps": self._config.eps})
         self.clusterer.use_default_constraints_as_supervision = self._config.use_default_constraints_as_supervision
         self.clusterer.dont_merge_cluster_seeds = self._config.dont_merge_cluster_seeds
+        self.clusterer.n_jobs = self._config.n_jobs
+        self.clusterer.classifier.n_job = self._config.n_jobs
 
     def predict_one(self, instance: Instance) -> Prediction:
         """

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ requirements = [r for r in open(requirements_file).read().split("\n") if not re.
 
 setuptools.setup(
     name="s2apler",
-    version="0.2.5",
+    version="0.2.6.dev0",
     description="S2APLER: Semantic Scholar (S2) Agglomeration of Papers with Low Error Rate",
     url="https://github.com/allenai/S2APLER",
     packages=setuptools.find_packages(),


### PR DESCRIPTION
This does three things:

1. sets default n_jobs to 1 for the service
2. respects n_jobs for both ai2-written multiprocessing
  things (the call to `featurizer.many_pairs_featurize` was
  actually getting the value baked into the pickled model)
3. turns off thread-level parallelism at one layer of lightgbm

This is to address issues we are seeing in prod
related to linear memory leak over time and frequent request
timeouts and killing of gunicorn workers. In particular, we
end up with orphaned, high-memory consuming processes
that cannot be killed due to kernel lock.

I deployed a test version of this to our s2apler timo endpoint--
it resolved the leak, gunicorn timeouts, and decreased p50
inference latency by ~50%.

![Screenshot 2023-09-22 at 3 20 51 PM](https://github.com/allenai/S2APLER/assets/1287054/61218943-345b-40c8-bcb9-69b336c695c8)
