### PR TITLE
Bump version to 0.2.7 + Python runtime to 3.11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8-bookworm
+FROM python:3.11-bookworm
 
 # install base packages
 RUN apt-get clean \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "s2apler"
-version = "0.2.6"
+version = "0.2.7"
 description = "S2APLER: Semantic Scholar (S2) Agglomeration of Papers with Low Error Rate"
 readme = "README.md"
 requires-python = ">=3.8"

--- a/requirements.in
+++ b/requirements.in
@@ -12,7 +12,7 @@ seaborn==0.12.1
 tqdm==4.64.1
 jellyfish==0.9.0
 pylatexenc==2.10
-awscli==1.27.12
+awscli>=1.29.0
 
 # For CI and testing
 pytest==7.2.0

--- a/s2apler/timo/config.yaml
+++ b/s2apler/timo/config.yaml
@@ -26,7 +26,7 @@ model_variants:
     artifacts_s3_path: s3://ai2-s2-research-public/paper_clustering_artifacts.tar.gz
 
     # Version of python required for model runtime, e.g. 3.7, 3.8, 3.9
-    python_version: "3.8.15"
+    python_version: "3.11"
 
     # Whether this model supports CUDA GPU acceleration
     cuda: false
@@ -67,7 +67,7 @@ model_variants:
     artifacts_s3_path: s3://ai2-s2-research-public/paper_clustering_artifacts_v0_2.tar.gz
 
     # Version of python required for model runtime, e.g. 3.7, 3.8, 3.9
-    python_version: "3.8.15"
+    python_version: "3.11"
 
     # Whether this model supports CUDA GPU acceleration
     cuda: false

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ requirements = [r for r in open(requirements_file).read().split("\n") if not re.
 
 setuptools.setup(
     name="s2apler",
-    version="0.2.6",
+    version="0.2.7",
     description="S2APLER: Semantic Scholar (S2) Agglomeration of Papers with Low Error Rate",
     url="https://github.com/allenai/S2APLER",
     packages=setuptools.find_packages(),


### PR DESCRIPTION
Originally cut the release tag for the URL+title hard-merge constraint that landed in #16. Now expanded to also bump the Python runtime to 3.11, so we collapse two TIMO redeploys into one.

## What ships in 0.2.7

1. URL+title hard-merge constraint (#16).
2. Python runtime bumped from 3.8.15 → 3.11.
   - `Dockerfile`: `python:3.8-bookworm` → `python:3.11-bookworm`
   - `s2apler/timo/config.yaml`: `python_version` `3.8.15` → `3.11` for both `s2apler_v0_1` and `s2apler_v0_2` variants
   - `requirements.in`: `awscli==1.27.12` → `awscli>=1.29.0` (old pin transitively required PyYAML<5.5, but PyYAML 5.4.1 doesn't build on py3.11 due to Cython 3 incompatibility; awscli 1.29+ relaxes the bound). `awscli` is not imported anywhere in `s2apler/`, `scripts/`, or `tests/` — it's a CLI passenger in the image.

## Verified locally

Full CI suite inside the rebuilt py3.11 container, all green:
- `pytest tests/` — 26/26 passed
- `flake8 s2apler` + `flake8 scripts/*.py` — clean
- `black --check` — clean
- `pytest --cov-fail-under=40` — passes

## TIMO redeploy steps after merge

1. `tt publish -c s2apler/timo/config.yaml` from this repo — publishes `s2apler==0.2.7` to the AI2 pypi mirror and uploads the updated `config.yaml` (now requesting py3.11) to `s3://ai2-timo-registry/config/s2apler/0.2.7.yaml`.
2. PR to `allenai/timo` bumping `timo_services/configs/s2apler_v1.py:model_pypi_package.version` from `0.2.6` → `0.2.7`. Merge auto-deploys via TC `SemanticScholar_SparkCluster_Timo_Services`.

Trained-weights tarball at `s3://ai2-s2-research-public/paper_clustering_artifacts_v0_2.tar.gz` is unchanged; same weights, new code + new Python runtime.

## Downtime expectation

Sole prod consumer is the AltPaperClustering worker (SQS-driven, in `allenai/scholar/papers/`). Brief s2apler-v1 outage during the TIMO redeploy → messages sit in `s2-corpus-AltPaperClustering-*-prod` queues until s2apler comes back. The worker's 10-min per-call timeout + 1 retry with 15s backoff on 5xx absorbs the rollout window. No synchronous user-facing impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)