### PR TITLE
Add arXiv id as a first-class merge constraint

### DIFF
--- a/s2apler/data.py
+++ b/s2apler/data.py
@@ -1,6 +1,7 @@
 from typing import Optional, Union, Dict, List, Any, Tuple, Set, NamedTuple
 
 import random
+import re
 import json
 import numpy as np
 import pandas as pd
@@ -74,6 +75,46 @@ class Paper(NamedTuple):
     source: Optional[str]
     block: Optional[str]
     source_uris: Optional[List[str]] = None
+    arxiv_id: Optional[str] = None
+
+
+RE_ARXIV_DOI = re.compile(r"^10\.48550/arxiv\.(.+)$", re.IGNORECASE)
+RE_ARXIV_VERSION = re.compile(r"v\d+$", re.IGNORECASE)
+
+
+def _normalize_arxiv_id(arxiv_id: Optional[str]) -> Optional[str]:
+    """Lowercase and strip a trailing version suffix (e.g. '2512.13961v2' -> '2512.13961')."""
+    if not arxiv_id:
+        return None
+    normalized = RE_ARXIV_VERSION.sub("", arxiv_id.strip().lower())
+    return normalized or None
+
+
+def extract_arxiv_id(
+    source: Optional[str],
+    source_id: Optional[str],
+    doi: Optional[str],
+    explicit: Optional[str] = None,
+) -> Optional[str]:
+    """Derive a normalized arXiv id from (in priority order) an explicit field, the arXiv
+    DataCite DOI '10.48550/arXiv.<id>', or an ArXiv-sourced record's source_id. Returns None if
+    none apply.
+
+    This backs a first-class arXiv-id merge constraint (see get_constraint). It is intentionally
+    kept out of `doi`: S2 does not synthesize the '10.48550/arXiv.<id>' DOI onto arXiv-only
+    records, so an arXiv-only record (source_id=<id>, doi=None) and a DBLP record for the same
+    paper (doi='10.48550/arXiv.<id>') otherwise share no hard identifier. Folding it into `doi`
+    instead would make a preprint and its published version (a real, different DOI) look like
+    disagreeing strong signals -- see `_strong_signals_disagree` / allenai/scholar#41863."""
+    if explicit:
+        return _normalize_arxiv_id(explicit)
+    if doi:
+        match = RE_ARXIV_DOI.match(doi.strip())
+        if match:
+            return _normalize_arxiv_id(match.group(1))
+    if source and source_id and source.lower() == "arxiv":
+        return _normalize_arxiv_id(source_id)
+    return None
 
 
 def _strong_signals_disagree(p1: "Paper", p2: "Paper") -> bool:
@@ -207,6 +248,12 @@ class PDData:
                 block=paper.get("block", None),
                 corpus_paper_id=paper.get("corpus_paper_id", None),
                 source_uris=paper.get("source_uris", None),
+                arxiv_id=extract_arxiv_id(
+                    paper.get("source", None),
+                    paper.get("source_id", None),
+                    paper.get("doi", None),
+                    paper.get("arxiv_id", None),
+                ),
             )
         logger.debug("loaded papers")
 
@@ -422,6 +469,12 @@ class PDData:
             return CLUSTER_SEEDS_LOOKUP["require"]
         elif paper_1.pdf_hash is not None and paper_2.pdf_hash is not None and paper_1.pdf_hash == paper_2.pdf_hash:
             # same pdf hash - same paper
+            return CLUSTER_SEEDS_LOOKUP["require"]
+        elif paper_1.arxiv_id is not None and paper_2.arxiv_id is not None and paper_1.arxiv_id == paper_2.arxiv_id:
+            # same arXiv id - same paper. arXiv-only records carry no DOI (S2 does not derive
+            # 10.48550/arXiv.<id>), so an ArXiv record (source_id=<id>) and a DBLP record for the
+            # same paper (doi=10.48550/arXiv.<id>) otherwise share no hard identifier and fall to
+            # the fuzzy model, which misses on short titles (e.g. "Olmo 3"). See allenai/scholar#41736.
             return CLUSTER_SEEDS_LOOKUP["require"]
         elif (
             paper_1.source_uris

--- a/s2apler/model.py
+++ b/s2apler/model.py
@@ -551,6 +551,8 @@ class Clusterer:
                             inverse_id_map[dataset.papers[paper_id].pdf_hash].append(label)
                         if dataset.papers[paper_id].pmid is not None:
                             inverse_id_map[dataset.papers[paper_id].pmid].append(label)
+                        if dataset.papers[paper_id].arxiv_id is not None:
+                            inverse_id_map[dataset.papers[paper_id].arxiv_id].append(label)
 
                     # now join any clusters that have overlapping ids
                     # this is a tad tricky because as we merge clusters, we need to
@@ -581,6 +583,8 @@ class Clusterer:
                         inverse_id_map[dataset.papers[paper_id].pdf_hash].append(label)
                     if dataset.papers[paper_id].pmid is not None:
                         inverse_id_map[dataset.papers[paper_id].pmid].append(label)
+                    if dataset.papers[paper_id].arxiv_id is not None:
+                        inverse_id_map[dataset.papers[paper_id].arxiv_id].append(label)
 
                 labels_for_nulls = []
                 for paper_id in paper_ids_for_nulls:
@@ -589,12 +593,15 @@ class Clusterer:
                     doi = dataset.papers[paper_id].doi
                     pmid = dataset.papers[paper_id].pmid
                     pdf_hash = dataset.papers[paper_id].pdf_hash
+                    arxiv_id = dataset.papers[paper_id].arxiv_id
                     if doi is not None and doi in inverse_id_map:
                         labels_for_nulls.append(inverse_id_map[doi][0])
                     elif pmid is not None and pmid in inverse_id_map:
                         labels_for_nulls.append(inverse_id_map[pmid][0])
                     elif pdf_hash is not None and pdf_hash in inverse_id_map:
                         labels_for_nulls.append(inverse_id_map[pdf_hash][0])
+                    elif arxiv_id is not None and arxiv_id in inverse_id_map:
+                        labels_for_nulls.append(inverse_id_map[arxiv_id][0])
                     else:
                         max_label += 1
                         labels_for_nulls.append(max_label)

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -230,3 +230,96 @@ class TestSourceUriConstraint(unittest.TestCase):
             }
         )
         assert dataset.get_constraint("1", "2") == CLUSTER_SEEDS_LOOKUP["require"]
+
+
+class TestArxivIdConstraint(unittest.TestCase):
+    """Same arXiv id -> must-merge, even when the two records share no other hard identifier.
+    Motivating case: an arXiv-only record (source=ArXiv, source_id=<id>, doi=None) and a DBLP
+    record for the same paper (doi=10.48550/arXiv.<id>). S2 does not synthesize the arXiv DOI
+    onto arXiv-only records, so without a first-class arXiv-id constraint these fall to the
+    fuzzy model and miss on short titles. See allenai/scholar#41736 and allenai/scholar#41735
+    (the "Olmo 3" duplicate)."""
+
+    @staticmethod
+    def _make_dataset(papers):
+        return PDData(papers=papers, name="t", mode="inference", balanced_pair_sample=False)
+
+    def test_arxiv_source_id_and_arxiv_doi_force_merge(self):
+        # The Olmo 3 case: ArXiv record (source_id, no doi) vs DBLP record (arXiv DataCite doi).
+        dataset = self._make_dataset(
+            {
+                "1": {"title": "Olmo 3", "authors": [], "source": "ArXiv", "source_id": "2512.13961", "block": "olmo"},
+                "2": {
+                    "title": "Olmo 3",
+                    "authors": [],
+                    "source": "DBLP",
+                    "doi": "10.48550/arXiv.2512.13961",
+                    "block": "olmo",
+                },
+            }
+        )
+        assert dataset.get_constraint("1", "2") == CLUSTER_SEEDS_LOOKUP["require"]
+
+    def test_arxiv_id_normalization_version_and_case(self):
+        # Version suffix stripped and case-folded so 'ArXiv.2512.13961' == 'source_id 2512.13961v2'.
+        dataset = self._make_dataset(
+            {
+                "1": {"title": "P", "authors": [], "source": "arxiv", "source_id": "2512.13961v2", "block": "p"},
+                "2": {"title": "P", "authors": [], "doi": "10.48550/ARXIV.2512.13961", "block": "p"},
+            }
+        )
+        assert dataset.get_constraint("1", "2") == CLUSTER_SEEDS_LOOKUP["require"]
+
+    def test_different_arxiv_ids_do_not_force_merge(self):
+        dataset = self._make_dataset(
+            {
+                "1": {"title": "P", "authors": [], "source": "ArXiv", "source_id": "2512.13961", "block": "p"},
+                "2": {"title": "P", "authors": [], "source": "ArXiv", "source_id": "2401.00001", "block": "p"},
+            }
+        )
+        assert dataset.get_constraint("1", "2") is None
+
+    def test_arxiv_id_not_derived_from_dblp_source_id(self):
+        # We deliberately do NOT parse the arXiv id out of a DBLP 'journals/corr/abs-...' source_id
+        # (dash-vs-dot ambiguity); the DBLP record's arXiv DataCite doi is the reliable signal.
+        dataset = self._make_dataset(
+            {
+                "1": {
+                    "title": "P",
+                    "authors": [],
+                    "source": "DBLP",
+                    "source_id": "journals/corr/abs-2512-13961",
+                    "block": "p",
+                }
+            }
+        )
+        assert dataset.papers["1"].arxiv_id is None
+
+    def test_arxiv_id_is_not_folded_into_doi(self):
+        # Guard against the _strong_signals_disagree regression: deriving an arXiv id must not
+        # populate `doi`, or a preprint and its published version would look like disagreeing DOIs.
+        dataset = self._make_dataset(
+            {"1": {"title": "P", "authors": [], "source": "ArXiv", "source_id": "2512.13961", "block": "p"}}
+        )
+        assert dataset.papers["1"].arxiv_id == "2512.13961"
+        assert dataset.papers["1"].doi is None
+
+    def test_arxiv_preprint_and_published_version_can_still_url_merge(self):
+        # An arXiv preprint (arxiv_id set, doi=None) and its published version (real journal doi)
+        # sharing a URL + title must still merge: the synthetic arXiv identity must not trip
+        # _strong_signals_disagree. See allenai/scholar#41863.
+        url = "https://example.org/paper.pdf"
+        dataset = self._make_dataset(
+            {
+                "1": {
+                    "title": "P",
+                    "authors": [],
+                    "source": "ArXiv",
+                    "source_id": "2512.13961",
+                    "source_uris": [url],
+                    "block": "p",
+                },
+                "2": {"title": "P", "authors": [], "doi": "10.1145/realjournal", "source_uris": [url], "block": "p"},
+            }
+        )
+        assert dataset.get_constraint("1", "2") == CLUSTER_SEEDS_LOOKUP["require"]


### PR DESCRIPTION
## Problem

Two corpus records for the **same arXiv paper** can share **no hard identifier**, so `get_constraint` can't force-merge them and the decision falls to the fuzzy model — which misses on short/generic titles.

Concretely (from allenai/scholar#41736 / #41735, the "Olmo 3" case, arXiv 2512.13961):

| Record | source | source_id | doi |
|--------|--------|-----------|-----|
| A | `ArXiv` | `2512.13961` | *(none)* |
| B | `DBLP` | `journals/corr/abs-2512-13961` | `10.48550/arXiv.2512.13961` |

S2 does **not** synthesize the arXiv DataCite DOI (`10.48550/arXiv.<id>`) onto arXiv-only records (verified: 0 of 10,685 arXiv-only 2025 corpus records carry it — it arrives via DBLP/Crossref). So A has no `doi`, B has no matching `pdf_hash`/`pmid`, the two share nothing, and `get_constraint` returns `None`. The title "Olmo 3" is too short for the fuzzy model to link them, so the paper split into two records — with references and citations scattered/zeroed across both.

## Change

Treat the **arXiv id as its own identifier class** and force-merge on arXiv-id equality, symmetric with `doi`/`pmid`/`pdf_hash`:

- `extract_arxiv_id(...)` derives a normalized arXiv id (lowercased, version suffix stripped) from — in priority order — an explicit `arxiv_id` field, the arXiv DataCite DOI `10.48550/arXiv.<id>`, or an `ArXiv`-sourced record's `source_id`. Populated on `Paper` at load time.
- New `require` branch in `get_constraint` on `arxiv_id` equality.
- `arxiv_id` added to the post-clustering id-overlap safety-net in `model.py` (both builders + the null-title rejoin), mirroring `doi`.

### Deliberately NOT a `doi` backfill

The arXiv id is kept as its own field and is **not** folded into `doi`. Folding it in would regress `_strong_signals_disagree` (allenai/scholar#41863): a preprint (synthetic `10.48550/arXiv.X`) and its published version (a real, different journal DOI) would then look like *disagreeing* strong signals and be blocked from the URL+title merge that currently joins them. A regression test guards this (`test_arxiv_preprint_and_published_version_can_still_url_merge`).

We intentionally do **not** parse the arXiv id out of a DBLP `journals/corr/abs-...` source_id (dash-vs-dot ambiguity); the DBLP record's arXiv DataCite DOI is the reliable signal.

## Tests

Added `TestArxivIdConstraint` (6 cases): the ArXiv↔DBLP-DOI merge (the Olmo 3 case), version/case normalization, different ids don't merge, DBLP-source_id is not parsed, arxiv_id not folded into doi, and the preprint↔published URL-merge regression guard.

Local CI (Docker image, Python 3.11): `black --check --line-length 120` ✅, `flake8` ✅. `pytest tests/test_data.py` → **17 passed** (the model.py-path tests need the full ML deps and will run in CI).

Refs: allenai/scholar#41736, allenai/scholar#41735, allenai/scholar#41863. Investigation: allenai/gas2own#279.